### PR TITLE
Enable inter-component access to server to satisfy xrefs

### DIFF
--- a/modules/classic_web_ui/pages/external_storage/external_storage.adoc
+++ b/modules/classic_web_ui/pages/external_storage/external_storage.adoc
@@ -4,5 +4,5 @@ The External Storage application allows you to mount external storage
 services, such as Google Drive, Dropbox, Amazon S3, SMB/CIFS
 fileservers, and FTP servers in ownCloud. Your ownCloud server
 administrator controls which of these are available to you. Please see
-xref:admin_manual:configuration/files/external_storage/configuration.adoc[External Storage Configuration] in the ownCloud
+xref:{latest-server-version}@server:admin_manual:configuration/files/external_storage/configuration.adoc[External Storage Configuration] in the ownCloud
 Administrator’s manual for configuration howtos and examples.

--- a/modules/classic_web_ui/pages/files/federated_cloud_sharing.adoc
+++ b/modules/classic_web_ui/pages/files/federated_cloud_sharing.adoc
@@ -8,7 +8,7 @@ Federation Sharing allows you to mount file shares from remote ownCloud
 servers, in effect creating your own cloud of ownClouds. You can create
 direct share links with users on other ownCloud servers.
 
-IMPORTANT: xref:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Sharing] has to be configured by the administrator.
+IMPORTANT: xref:{latest-server-version}@server:admin_manual:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Sharing] has to be configured by the administrator.
 
 == How Federated Sharing Works
 

--- a/modules/classic_web_ui/pages/files/large_file_upload.adoc
+++ b/modules/classic_web_ui/pages/files/large_file_upload.adoc
@@ -12,5 +12,5 @@ you require larger upload limits than have been provided by the default
 
 * Contact your administrator to request an increase in these variables
 * Refer to the section in the
-xref:admin_manual:configuration/files/big_file_upload_configuration.adoc[Admin Documentation]
+xref:{latest-server-version}@server:admin_manual:configuration/files/big_file_upload_configuration.adoc[Admin Documentation]
 that describes how to manage file upload size limits.

--- a/modules/classic_web_ui/pages/files/webgui/custom_groups.adoc
+++ b/modules/classic_web_ui/pages/files/webgui/custom_groups.adoc
@@ -16,7 +16,7 @@ feature called "Custom Groups". Here’s how to use it.
 == Creating Custom Groups
 
 Assuming that your ownCloud administrator’s already
-xref:admin_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
+xref:{latest-server-version}@server:admin_manual:configuration/user/user_configuration.adoc#enabling-custom-groups[enabled custom groups];
  under the admin menu, in the top right-hand corner,
 click btn:[Settings] (1). Then, in the main menu on the settings page,
 in "**Personal**" section, click the option: btn:[Customgroups] (2).

--- a/modules/classic_web_ui/pages/files/webgui/search.adoc
+++ b/modules/classic_web_ui/pages/files/webgui/search.adoc
@@ -3,7 +3,7 @@
 
 == Introduction
 
-ownCloud comes with a regular search function allowing you to find files by their file name or parts of it. Click on the the magnifier icon in the upper right-hand corner of the web interface. In addition, the Full Text Search app can be enabled. This is something the system administrator needs to take care of. For more information on deploying it, refer to the respective section in the xref:admin_manual:configuration/search/index.adoc[Admin Manual].
+ownCloud comes with a regular search function allowing you to find files by their file name or parts of it. Click on the the magnifier icon in the upper right-hand corner of the web interface. In addition, the Full Text Search app can be enabled. This is something the system administrator needs to take care of. For more information on deploying it, refer to the respective section in the xref:{latest-server-version}@server:admin_manual:configuration/search/index.adoc[Admin Manual].
 
 == Regular Search
 

--- a/modules/classic_web_ui/pages/files/webgui/sharing.adoc
+++ b/modules/classic_web_ui/pages/files/webgui/sharing.adoc
@@ -35,7 +35,7 @@ or group name ownCloud will automatically complete it for you, if possible.
 [NOTE]
 ====
 From 10.0.8, user and group name search results are dependent on a new
-xref:admin_manual:configuration/server/config_sample_php_parameters.adoc[configuration setting],
+xref:{latest-server-version}@server:admin_manual:configuration/server/config_sample_php_parameters.adoc[configuration setting],
 called `user.search_min_length` (it is set to 4 by default).
 This setting helps to aid search performance but requires that search
 terms contain at least the defined number of characters. Consequently,

--- a/modules/classic_web_ui/pages/personal_settings/storage.adoc
+++ b/modules/classic_web_ui/pages/personal_settings/storage.adoc
@@ -9,4 +9,4 @@ image::personal-settings/storage/external-storage.png[]
 
 == Configuration
 
-To configure one or more external storages, please refer to the xref:admin_manual:configuration/files/external_storage/index.adoc[External Storage documentation].
+To configure one or more external storages, please refer to the xref:{latest-server-version}@server:admin_manual:configuration/files/external_storage/index.adoc[External Storage documentation].

--- a/modules/classic_web_ui/pages/pim/sync_ios.adoc
+++ b/modules/classic_web_ui/pages/pim/sync_ios.adoc
@@ -41,4 +41,4 @@ Your calendar will now be visible in the Calendar application
 
 Now should now find your contacts in the address book of your iPhone.
 If it’s still not working, have a look at the
-xref:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
+xref:{latest-server-version}@server:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.

--- a/modules/classic_web_ui/pages/pim/sync_osx.adoc
+++ b/modules/classic_web_ui/pages/pim/sync_osx.adoc
@@ -44,4 +44,4 @@ with your favorite text editor.
 . You may have to restart addressbook once more. After this, it should work.
 
 If it’s still not working, have a look at the
-xref:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.
+xref:{latest-server-version}@server:admin_manual:configuration/general_topics/general_troubleshooting.adoc#troubleshooting-contacts-calendar[Troubleshooting Contacts & Calendar] guides.

--- a/modules/classic_web_ui/partials/configuration/files/encryption/not-encrypted-files.adoc
+++ b/modules/classic_web_ui/partials/configuration/files/encryption/not-encrypted-files.adoc
@@ -3,7 +3,7 @@
 === The following data *is* encrypted:
 
 * Users' _files_ in their home directory trees _if enabled_ by the admin. +
-Location: `data/<user>/files`, see the: xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command set]
+Location: `data/<user>/files`, see the: xref:{latest-server-version}@server:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command set]
 * External storage _if enabled_ either by the user or by the admin
 
 === The following is *never* encrypted:
@@ -22,4 +22,4 @@ Note that there may be other not mentioned files that are not encrypted.
 
 If not otherwise decided by the admin, only new and changed files after enabling encryption are encrypted.
 
-NOTE: An admin can encrypt existing files post enabling encryption via an xref:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command].
+NOTE: An admin can encrypt existing files post enabling encryption via an xref:{latest-server-version}@server:admin_manual:configuration/server/occ_command.adoc#encryption[occ encryption command].

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,11 @@ content:
   - url: .
     branches:
     - HEAD
+  # the docs-server git is just present for the test build to satisfy used refrences
+  # the real build is made in the docs repo
+  - url: https://github.com/owncloud/docs-server.git
+    branches:
+    - master
 
 ui:
   output_dir: assets
@@ -35,6 +40,29 @@ asciidoc:
     oc-marketplace-url: 'https://marketplace.owncloud.com'
     oc-central-url: 'https://central.owncloud.org'
     oc-support-url: 'https://owncloud.com/support'
+#   server
+    # note that the version attributes just need to be present and have next as key
+    # as they are just here for the test build
+    latest-server-version: 'next'
+    previous-server-version: 'next'
+    latest-server-download-version: 'next'
+    current-server-version: 'next'
+    oc-changelog-url: 'https://owncloud.com/changelog/server/'
+    oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
+    oc-examples-server-url: 'https://owncloud.install.com/owncloud'
+    oc-examples-server-ip: '127.0.0.1'
+    oc-examples-username: 'username'
+    oc-examples-password: 'password'
+    oc-complete-name: 'owncloud-complete-20220112'
+    occ-command-example-prefix: 'sudo -u www-data php occ'
+    occ-command-example-prefix-no-sudo: 'php occ'
+    php-net-url: 'https://www.php.net'
+    php-supported-versions-url: 'https://www.php.net/supported-versions.php'
+    http-status-codes-base-url: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Status'
+    std-port-http: '8080'
+    std-port-memcache: '11211'
+    std-port-mysql: '3306'
+    std-port-redis: '6379'
 #   user
     latest-user-version: 'next'
     previous-user-version: 'next'


### PR DESCRIPTION
Enable inter-component access to server to satisfy xrefs.

Having this, we do proper cross referencing to the server when building locally.
The use of `next` in the attributes eases maintenance as we then do not need to maintain version changes.

When buidling via docs, site.yml is automatically satisfied as already present and the xrefs are resolved correctly 